### PR TITLE
Remove unused notification timestamp on JB and above

### DIFF
--- a/src/main/java/se/poochoo/reminder/ReminderHelper.java
+++ b/src/main/java/se/poochoo/reminder/ReminderHelper.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.media.RingtoneManager;
 import android.net.Uri;
+import android.os.Build;
 import android.util.SparseIntArray;
 
 import java.util.HashMap;
@@ -151,6 +152,9 @@ public class ReminderHelper {
                 .setDeleteIntent(cancelIntent(context, selector))
                 .setContentIntent(contentIntent)
                 .setContentText(textContent);
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1){
+            not.setShowWhen(false);
+        }
         if (showActionMessage && displayItem.hasProximityAssessment()) {
             Integer actionMessage = PROXIMITY_MESSAGES.get(listDataItem.getDisplayItem().getProximityAssessment());
             if (actionMessage != null) {


### PR DESCRIPTION
As we are currently not using the time functionality we should hide it. This is however not possible on pre api Jelly Bean MR1. This adds a check to make sure that the code is not run on devices that are not compatible.

But Theo.. Why are we not using the time place thing? Because we want to be able to tell the user both the time that is left and the time for the departure like this 2 min (12:47). While this field will only enable us to have one of then a a time. Therefore no! :)
