### PR TITLE
Add reminder notification for multiple departures

### DIFF
--- a/src/main/java/se/poochoo/DialogActivity.java
+++ b/src/main/java/se/poochoo/DialogActivity.java
@@ -55,6 +55,7 @@ public class DialogActivity extends Activity implements NetworkInterface.Respons
     public int dialogDepartureColor;
     private long dataLoadedAt;
     private MenuItem starDepartureItem;
+    private MenuItem notifyDepartureItem;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -68,12 +69,9 @@ public class DialogActivity extends Activity implements NetworkInterface.Respons
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.departure, menu);
-
         starDepartureItem = menu.findItem(R.id.action_star);
-
         if (selectedData.isPromoted(listDataItem.getSelector())){
             starDepartureItem.setChecked(true);
             starDepartureItem.setIcon(R.drawable.icon_star_white_on);
@@ -81,7 +79,9 @@ public class DialogActivity extends Activity implements NetworkInterface.Respons
             starDepartureItem.setChecked(false);
             starDepartureItem.setIcon(R.drawable.icon_star_white_off);
         }
-
+        notifyDepartureItem = menu.findItem(R.id.action_notification);
+        notifyDepartureItem.setChecked(true);
+        notifyDepartureItem.setIcon(R.drawable.action_remind);
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -98,6 +98,9 @@ public class DialogActivity extends Activity implements NetworkInterface.Respons
                     item.setIcon(R.drawable.icon_star_white_on);
                     selectedData.storeAction(listDataItem.getSelector(), SelectionUserDataSource.SelectionType.PROMOTE);
                 }
+                break;
+            case R.id.action_notification:
+                showTrackingNotification(0);
                 break;
         }
         return super.onOptionsItemSelected(item);

--- a/src/main/res/menu/departure.xml
+++ b/src/main/res/menu/departure.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-
     <item
         android:id="@+id/action_star"
         android:orderInCategory="300"
         android:showAsAction="always"
         android:checkable="true"
-        android:title="Star departure"
-        />
-
+        android:title="Star departure" />
+    <item
+        android:id="@+id/action_notification"
+        android:orderInCategory="200"
+        android:showAsAction="always"
+        android:checkable="true"
+        android:title="Notify departure" />
 </menu>


### PR DESCRIPTION
This adds an actionbar item for a full departure to be start a departure tracking notification.
MVP:
- Should stay in place until the user deletes the notification
- Should have a button to switch to the next departure (and if its the last track the previous)
